### PR TITLE
feat: Add privacy provider class for mod_viewer3d

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_viewer3d\privacy;
+
+/**
+ * Class provider
+ *
+ * @package    mod_viewer3d
+ * @copyright  2025 GFrancV <https://www.gfrancv.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}


### PR DESCRIPTION
This pull request adds a new privacy provider class for the `mod_viewer3d` plugin to comply with Moodle's privacy API. The new class declares that the plugin does not store any personal user data.

Privacy compliance:

* Added a `provider` class in `classes/privacy/provider.php` implementing `core_privacy\local\metadata\null_provider`, with a `get_reason()` method that returns a language string identifier indicating no user data is stored.