### PR TITLE
feat: Update version and release number to 0.2.1 for mod_viewer3d

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'mod_viewer3d';
-$plugin->release      = '0.2.0';
-$plugin->version      = 2025090300;
+$plugin->release      = '0.2.1';
+$plugin->version      = 2025090410;
 $plugin->requires     = 2023042400;
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
This pull request updates the version information for the `mod_viewer3d` plugin. The release and version numbers have been incremented to reflect a new release.

- Versioning update:
  * Increased the `release` from `0.2.0` to `0.2.1` and the `version` from `2025090300` to `2025090410` in `version.php` to mark a new plugin release.