### PR TITLE
style: Clean up code formatting and improve readability across multiple files

### DIFF
--- a/backup/moodle2/backup_viewer3d_activity_task.class.php
+++ b/backup/moodle2/backup_viewer3d_activity_task.class.php
@@ -26,7 +26,6 @@ require_once($CFG->dirroot . '/mod/viewer3d/backup/moodle2/backup_viewer3d_steps
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class backup_viewer3d_activity_task extends backup_activity_task {
-
     /**
      * No specific settings for this activity
      */
@@ -52,11 +51,11 @@ class backup_viewer3d_activity_task extends backup_activity_task {
         $base = preg_quote($CFG->wwwroot, "/");
 
         // Link to the list of viewer3ds.
-        $search = "/(".$base."\/mod\/viewer3d\/index.php\?id\=)([0-9]+)/";
+        $search = "/({$base}\/mod\/viewer3d\/index.php\?id\=)([0-9]+)/";
         $content = preg_replace($search, '$@VIEWER3DINDEX*$2@$', $content);
 
         // Link to viewer3d view by moduleid.
-        $search = "/(".$base."\/mod\/viewer3d\/view.php\?id\=)([0-9]+)/";
+        $search = "/({$base}\/mod\/viewer3d\/view.php\?id\=)([0-9]+)/";
         $content = preg_replace($search, '$@VIEWER3DVIEWBYID*$2@$', $content);
 
         return $content;

--- a/backup/moodle2/backup_viewer3d_stepslib.php
+++ b/backup/moodle2/backup_viewer3d_stepslib.php
@@ -22,7 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class backup_viewer3d_activity_structure_step extends backup_activity_structure_step {
-
     /**
      * Backup structure
      */
@@ -31,8 +30,11 @@ class backup_viewer3d_activity_structure_step extends backup_activity_structure_
         // To know if we are including userinfo.
         $userinfo = $this->get_setting_value('userinfo');
 
-        $viewer3d = new backup_nested_element('viewer3d', ['id'],
-            ['course', 'name', 'intro', 'introformat', 'stlfile', 'timecreated', 'timemodified']);
+        $viewer3d = new backup_nested_element(
+            'viewer3d',
+            ['id'],
+            ['course', 'name', 'intro', 'introformat', 'stlfile', 'timecreated', 'timemodified']
+        );
 
         // Define sources.
         $viewer3d->set_source_table('viewer3d', ['id' => backup::VAR_ACTIVITYID]);

--- a/backup/moodle2/restore_viewer3d_activity_task.class.php
+++ b/backup/moodle2/restore_viewer3d_activity_task.class.php
@@ -26,7 +26,6 @@ require_once($CFG->dirroot . '/mod/viewer3d/backup/moodle2/restore_viewer3d_step
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class restore_viewer3d_activity_task extends restore_activity_task {
-
     /**
      * Define (add) particular settings this activity can have
      */

--- a/backup/moodle2/restore_viewer3d_stepslib.php
+++ b/backup/moodle2/restore_viewer3d_stepslib.php
@@ -22,7 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class restore_viewer3d_activity_structure_step extends restore_activity_structure_step {
-
     /**
      * Structure step to restore one viewer3d activity
      *

--- a/classes/event/course_module_instance_list_viewed.php
+++ b/classes/event/course_module_instance_list_viewed.php
@@ -24,7 +24,6 @@ namespace mod_viewer3d\event;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class course_module_instance_list_viewed extends \core\event\course_module_instance_list_viewed {
-
     /**
      * Create the event from course record.
      *

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -24,7 +24,6 @@ namespace mod_viewer3d\event;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class course_module_viewed extends \core\event\course_module_viewed {
-
     /**
      * Init method.
      *

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,7 +24,6 @@ namespace mod_viewer3d\privacy;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements \core_privacy\local\metadata\null_provider {
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.

--- a/index.php
+++ b/index.php
@@ -43,8 +43,10 @@ echo $OUTPUT->heading($modulenameplural);
 $instances = get_all_instances_in_course('viewer3d', $course);
 
 if (empty($instances)) {
-    notice(get_string('thereareno', 'moodle', $modulenameplural),
-        new moodle_url('/course/view.php', ['id' => $course->id]));
+    notice(
+        get_string('thereareno', 'moodle', $modulenameplural),
+        new moodle_url('/course/view.php', ['id' => $course->id])
+    );
 }
 
 $table = new html_table();
@@ -56,7 +58,7 @@ $table = new html_table();
 $table->attributes['class'] = 'generaltable mod_index';
 
 if ($usesections) {
-    $strsectionname = get_string('sectionname', 'format_'.$course->format);
+    $strsectionname = get_string('sectionname', "format_{$course->format}");
     $table->head  = [$strsectionname, get_string('name')];
     $table->align = ['left', 'left'];
 } else {
@@ -69,7 +71,8 @@ foreach ($instances as $instance) {
     $link = html_writer::link(
         new moodle_url('/mod/viewer3d/view.php', ['id' => $instance->coursemodule]),
         format_string($instance->name, true),
-        $attrs);
+        $attrs
+    );
 
     if ($usesections) {
         $table->data[] = [$instance->section, $link];

--- a/lib.php
+++ b/lib.php
@@ -174,7 +174,7 @@ function viewer3d_get_file_info($browser, $areas, $course, $cm, $context, $filea
  * @param array $options Additional options affecting the file serving
  * @return bool False if file not found, does not return if found - just sends the file
  */
-function viewer3d_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options=[]) {
+function viewer3d_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = []) {
     if ($context->contextlevel != CONTEXT_MODULE) {
         return false;
     }
@@ -187,7 +187,7 @@ function viewer3d_pluginfile($course, $cm, $context, $filearea, $args, $forcedow
 
     $itemid = array_shift($args);
     $filename = array_pop($args);
-    $filepath = $args ? '/'.implode('/', $args).'/' : '/';
+    $filepath = $args ? '/' . implode('/', $args) . '/' : '/';
 
     $fs = get_file_storage();
     $file = $fs->get_file($context->id, 'mod_viewer3d', $filearea, $itemid, $filepath, $filename);

--- a/mod_form.php
+++ b/mod_form.php
@@ -26,7 +26,6 @@ require_once($CFG->dirroot . '/course/moodleform_mod.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class mod_viewer3d_mod_form extends moodleform_mod {
-
     /**
      * Defines forms elements
      */
@@ -69,17 +68,17 @@ class mod_viewer3d_mod_form extends moodleform_mod {
      /**
       * Prepares the form before data are set.
       *
-      * @param array $default_values
+      * @param array $defaultvalues The default values of the form
       */
     public function data_preprocessing(&$defaultvalues) {
         $draftitemid = file_get_submitted_draft_itemid('stlfile');
         file_prepare_draft_area(
-        $draftitemid,
-        $this->context->id,
-        'mod_viewer3d',
-        'stlfile',
-        0,
-        ['subdirs' => 0, 'maxfiles' => 1]
+            $draftitemid,
+            $this->context->id,
+            'mod_viewer3d',
+            'stlfile',
+            0,
+            ['subdirs' => 0, 'maxfiles' => 1]
         );
         $defaultvalues['stlfile'] = $draftitemid;
     }

--- a/view.php
+++ b/view.php
@@ -22,8 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require(__DIR__.'/../../config.php');
-require_once(__DIR__.'/lib.php');
+require(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
 
 // Course module id.
 $id = optional_param('id', 0, PARAM_INT);


### PR DESCRIPTION
This pull request primarily refactors code for improved readability and consistency, with a focus on formatting changes and minor string interpolation updates. The changes do not alter functionality but enhance code maintainability and clarity.

Formatting and Readability Improvements:
* Reformatted multi-line function calls and conditionals for better readability in `backup_viewer3d_stepslib.php` and `index.php`. [[1]](diffhunk://#diff-5febb7d6f25a9f3c4728dd9f796ac3e70a1c4f4f25c69a288a394eaa8ce82281L34-R37) [[2]](diffhunk://#diff-7413d6453f901e939bbd840c8f0d1c7b20c2ca0e7f71741e4e07c6cf036f16c0L46-R49) [[3]](diffhunk://#diff-7413d6453f901e939bbd840c8f0d1c7b20c2ca0e7f71741e4e07c6cf036f16c0L72-R75)
* Removed unnecessary blank lines after class declarations across multiple files to maintain code style consistency. [[1]](diffhunk://#diff-9b19fab6bda7c6ec14e8025881ce09ef3ad3b70cdbbec44421296f7028b3e0d4L29) [[2]](diffhunk://#diff-5febb7d6f25a9f3c4728dd9f796ac3e70a1c4f4f25c69a288a394eaa8ce82281L25) [[3]](diffhunk://#diff-86bf84e323a78b876407b1145ea5c48b7ef73aa4cf470ac0b5e43ac71d734847L29) [[4]](diffhunk://#diff-7eb2f473260e305f9c1049160562ff292492e3d381103c521cccb759b7cab35bL25) [[5]](diffhunk://#diff-5371d2a17b9a3e54c3346e5285c96ecfd79e204e0275e78fb00637b2aa9c377cL27) [[6]](diffhunk://#diff-dd41c192f6dc07362743b2ef3933a41b0e87053ea32731b84ae40ccb98d7bd9aL27) [[7]](diffhunk://#diff-76112e9cfbad081959021ab9520f48deaf00fbcaa69aca479f03d034fe624519L27) [[8]](diffhunk://#diff-aa9511a4531a05e51ca336401c5f892ca096725e2f94b6fce8dd8f0c9fe3b181L29)

String Handling Consistency:
* Updated string interpolation to use curly braces for variables in regular expressions and language string keys, improving clarity in `backup_viewer3d_activity_task.class.php` and `index.php`. [[1]](diffhunk://#diff-9b19fab6bda7c6ec14e8025881ce09ef3ad3b70cdbbec44421296f7028b3e0d4L55-R58) [[2]](diffhunk://#diff-7413d6453f901e939bbd840c8f0d1c7b20c2ca0e7f71741e4e07c6cf036f16c0L59-R61)

Documentation and Naming:
* Clarified a parameter name in a docblock for `data_preprocessing` in `mod_form.php` for better documentation accuracy.