### PR TITLE
feat: Add CI workflow for Moodle Plugin with PHP and database support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,163 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.2'
+            moodle-branch: 'MOODLE_500_STABLE'
+            database: pgsql
+          - php: '8.3'
+            moodle-branch: 'MOODLE_500_STABLE'
+            database: pgsql
+          - php: '8.4'
+            moodle-branch: 'MOODLE_500_STABLE'
+            database: pgsql
+          - php: '8.2'
+            moodle-branch: 'MOODLE_500_STABLE'
+            database: mariadb
+          - php: '8.3'
+            moodle-branch: 'MOODLE_500_STABLE'
+            database: mariadb
+          - php: '8.4'
+            moodle-branch: 'MOODLE_500_STABLE'
+            database: mariadb
+          - php: '8.1'
+            moodle-branch: 'MOODLE_405_STABLE'
+            database: pgsql
+          - php: '8.2'
+            moodle-branch: 'MOODLE_405_STABLE'
+            database: pgsql
+          - php: '8.3'
+            moodle-branch: 'MOODLE_405_STABLE'
+            database: pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_405_STABLE'
+            database: mariadb
+          - php: '8.2'
+            moodle-branch: 'MOODLE_405_STABLE'
+            database: mariadb
+          - php: '8.3'
+            moodle-branch: 'MOODLE_405_STABLE'
+            database: mariadb
+          - php: '8.1'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: pgsql
+          - php: '8.2'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: pgsql
+          - php: '8.3'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: mariadb
+          - php: '8.2'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: mariadb
+          - php: '8.3'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: mariadb
+          - php: '8.0'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: pgsql
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: pgsql
+          - php: '8.0'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: mariadb
+          - php: '8.1'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: mariadb
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: mariadb
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker --max-warnings 0
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning
+
+      - name: Behat features
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome --auto-rerun 0


### PR DESCRIPTION
This pull request introduces a comprehensive GitHub Actions workflow for continuous integration (CI) of the Moodle plugin. The workflow is designed to automatically test the plugin across a matrix of supported PHP versions, Moodle branches, and database backends, ensuring compatibility and code quality.

Key additions in this CI setup:

**CI Workflow Setup:**

* Adds a new `.github/workflows/ci.yml` file that defines a GitHub Actions workflow named "Moodle Plugin CI", triggered on every push and pull request.

**Testing Matrix and Services:**

* Configures a test matrix covering multiple combinations of PHP versions (8.0–8.4), Moodle branches (MOODLE_403_STABLE to MOODLE_500_STABLE), and databases (PostgreSQL and MariaDB), to ensure broad compatibility.
* Sets up PostgreSQL and MariaDB as service containers for database testing, including health checks for both services.

**CI Steps and Quality Checks:**

* Installs and configures the required PHP environment and dependencies for each matrix entry, including the use of `moodle-plugin-ci` tooling.
* Runs a series of automated checks: PHP linting, PHP Mess Detector, Moodle Code Checker, PHPDoc validation, plugin validation, PHPUnit tests, and Behat feature tests, ensuring code quality and adherence to Moodle