### PR TITLE
feat: Update CI workflow to use moodle-plugin-ci-action for PHP setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,54 +110,10 @@ jobs:
         with:
           path: plugin
 
-      - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+      - name: Moodle CI PHP ${{ matrix.php }} Moodle ${{ matrix.moodle-branch }} DB ${{ matrix.database }}
+        uses: gfrancv/moodle-plugin-ci-action@v1.1.0
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ matrix.extensions }}
-          ini-values: max_input_vars=5000
-          coverage: none
-
-      - name: Initialise moodle-plugin-ci
-        run: |
-          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
-          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
-          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
-          sudo locale-gen en_AU.UTF-8
-          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
-
-      - name: Install moodle-plugin-ci
-        run: |
-          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
-        env:
-          DB: ${{ matrix.database }}
-          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
-
-      - name: PHP Lint
-        if: ${{ always() }}
-        run: moodle-plugin-ci phplint
-
-      - name: PHP Mess Detector
-        continue-on-error: true # This step will show errors but will not fail
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpmd
-
-      - name: Moodle Code Checker
-        if: ${{ always() }}
-        run: moodle-plugin-ci codechecker --max-warnings 0
-
-      - name: Moodle PHPDoc Checker
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpdoc
-
-      - name: Validating
-        if: ${{ always() }}
-        run: moodle-plugin-ci validate
-
-      - name: PHPUnit tests
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpunit --fail-on-warning
-
-      - name: Behat features
-        if: ${{ always() }}
-        run: moodle-plugin-ci behat --profile chrome --auto-rerun 0
+          moodle-branch: ${{ matrix.moodle-branch }}
+          database: ${{ matrix.database }}
+          plugin-path: ./plugin


### PR DESCRIPTION
This pull request streamlines the CI workflow for the project by replacing manual setup steps with a dedicated GitHub Action for Moodle plugin testing. The new approach simplifies the configuration and maintenance of the CI pipeline.

**CI Workflow Modernization:**

* Replaced manual PHP and Moodle plugin setup steps with the `gfrancv/moodle-plugin-ci-action@v1.1.0` GitHub Action, consolidating environment setup and test execution into a single step.
* Removed explicit installation and initialization commands for `moodle-plugin-ci`, as well as individual steps for linting, code checking, validation, and test execution, which are now handled by the new action.
* Updated input parameters for the CI job to use the new action's configuration options (`php-version`, `moodle-branch`, `database`, and `plugin-path`).