### PR TITLE
Bump version to 0.2.3 and update release date

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'mod_viewer3d';
-$plugin->release      = '0.2.2';
-$plugin->version      = 2025091500;
+$plugin->release      = '0.2.3';
+$plugin->version      = 2025092511;
 $plugin->requires     = 2023042400;
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
This pull request updates the version information for the `mod_viewer3d` plugin. The release and version numbers have been incremented to reflect a new release.

* Increased the release number to `'0.2.3'` and updated the version number to `2025092511` in `version.php` to prepare for the new plugin release.